### PR TITLE
Add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+Contributing
+============
+
+We welcome contributions in the form of GitHub issues or pull requests. A [guide to contributing via GitHub][guide] is available.
+
+The documents are licensed under the [Creative Commons CC0 1.0 license][CC0]. Please review CC0 1.0 and agree to license your contributions under the same terms.
+
+The project's [README file][readme] contains a legal disclaimer that speaks on behalf of all contributors. Please review the disclaimer and confirm your agreement with it.
+
+[guide]: http://www.seriesseed.com/posts/2013/02/for-law-nerds-and-real-nerds.html
+
+[CC0]: http://creativecommons.org/publicdomain/zero/1.0/
+
+[readme]: ./README.md

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 Welcome to the GitHub repository for the Series Seed Documents, a standardized set of legal documents that can be quickly and easily deployed for a seed investment round.  For more information on this release of the documents, please refer to the [Series Seed blog](http://www.seriesseed.com) or our [Release Notes](https://github.com/seriesseed/equity/blob/master/RELEASENOTES.md) here on GitHub.
 
-## Contributing
-
-We welcome contributions in the form of issues or pull requests. If you need help with this process, we've created a brief overview [here](http://www.seriesseed.com/posts/2013/02/for-law-nerds-and-real-nerds.html).
-
 ## License
 
 Series Seed is open sourced under [CC0] (http://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
This pull request moves information about contributing to the Series Seed Documents to a [CONTRIBUTING file](https://github.com/blog/1184-contributing-guidelines). It also adds notes to the contributing guidelines directing authors' attention to the project's license and disclaimer language.
