### PR TITLE
Add text format configuration files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = false
+trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
This pull request adds a `.gitattributes` file that tells the revision control system to harmonize files edited in Windows and otherwise, as well as an `.editorconfig` file that many text editors will use to help format documents uniformly.
