### PR TITLE
Use Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+---
+language: "node_js"
+node_js: "stable"
+script: "make lint"
+sudo: false


### PR DESCRIPTION
This pull request adds a configuration file for [Travis CI](http://travis-ci.com), a free-for-open-source service that will run automated tests, build releases, and do other kinds of tasks for us automatically.

Enabling Travis CI for private, rather than public, repositories is mighty expensive, so this will wait until first public release of Series Next.

This branch is off #9, the branch for build automation.
