### PR TITLE
Add zip to apt-get line

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -4,7 +4,7 @@ Building the Series Next Documents
 ZIP archives for each release are created with [Pandoc](http://pandoc.org/) and [Rake](https://github.com/ruby/rake), a build tool in the [Ruby programming language](https://www.ruby-lang.org/en/). To install all the necessary tools and build the ZIP file on a [Debian Linux](http://debian.org/) computer, use the following commands:
 
 ```bash
-sudo apt-get install git pandoc bundler
+sudo apt-get install git pandoc bundler zip
 git clone https://github.com/seriesnext/seriesnext
 cd seriesnext
 bundle install


### PR DESCRIPTION
I tried this on my Digital Ocean instance, and it failed because `zip` wasn't installed.
